### PR TITLE
設定ファイル作成（Deno, Nuxt, Biome）#3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Supabase Configuration
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key-here

--- a/README.md
+++ b/README.md
@@ -273,3 +273,6 @@ MIT
 - デプロイ＆調整: 1時間
 
 Happy Coding! 🐱✨
+
+assetsフォルダは、app配下に書くこと
+https://github.com/nuxt/nuxt/issues/31628

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,0 +1,19 @@
+* {
+	margin: 0;
+	padding: 0;
+	box-sizing: border-box;
+}
+
+body {
+	font-family:
+		-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+	line-height: 1.6;
+	color: #333;
+	background-color: #f5f5f5;
+}
+
+.container {
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 2rem 1rem;
+}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,45 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"experimentalScannerIgnores": [".nuxt", ".output", "node_modules", "dist"]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"indentWidth": 2,
+		"lineWidth": 100
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"style": {
+				"useConst": "error",
+				"useTemplate": "warn"
+			},
+			"suspicious": {
+				"noExplicitAny": "warn"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "asNeeded"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,20 @@
+{
+	"tasks": {
+		"dev": "nuxt dev",
+		"build": "nuxt build",
+		"preview": "nuxt preview",
+		"generate": "nuxt generate",
+		"lint": "biome lint .",
+		"format": "biome format --write .",
+		"check": "biome check --apply .",
+		"typecheck": "nuxt typecheck"
+	},
+	"imports": {
+		"#app": "https://deno.land/x/nuxt/dist/app/index.js"
+	},
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"jsxImportSource": "vue"
+	},
+	"nodeModulesDir": "auto"
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,12 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:nuxt@^4.3.0": "4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1",
+    "npm:@biomejs/biome@*": "2.3.14",
+    "npm:@biomejs/biome@2.3.14": "2.3.14",
+    "npm:@biomejs/biome@^2.3.14": "2.3.14",
+    "npm:@types/node@*": "24.2.0",
+    "npm:nuxt@4.3.0": "4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_@types+node@24.2.0_@biomejs+biome@2.3.14",
+    "npm:nuxt@^4.3.0": "4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_@types+node@24.2.0_@biomejs+biome@2.3.14",
     "npm:vue-router@^4.6.4": "4.6.4_vue@3.5.27",
     "npm:vue@^3.5.27": "3.5.27"
   },
@@ -201,6 +206,60 @@
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
       ]
+    },
+    "@biomejs/biome@2.3.14": {
+      "integrity": "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA==",
+      "optionalDependencies": [
+        "@biomejs/cli-darwin-arm64",
+        "@biomejs/cli-darwin-x64",
+        "@biomejs/cli-linux-arm64",
+        "@biomejs/cli-linux-arm64-musl",
+        "@biomejs/cli-linux-x64",
+        "@biomejs/cli-linux-x64-musl",
+        "@biomejs/cli-win32-arm64",
+        "@biomejs/cli-win32-x64"
+      ],
+      "bin": true
+    },
+    "@biomejs/cli-darwin-arm64@2.3.14": {
+      "integrity": "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@biomejs/cli-darwin-x64@2.3.14": {
+      "integrity": "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@biomejs/cli-linux-arm64-musl@2.3.14": {
+      "integrity": "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@biomejs/cli-linux-arm64@2.3.14": {
+      "integrity": "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@biomejs/cli-linux-x64-musl@2.3.14": {
+      "integrity": "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@biomejs/cli-linux-x64@2.3.14": {
+      "integrity": "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@biomejs/cli-win32-arm64@2.3.14": {
+      "integrity": "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@biomejs/cli-win32-x64@2.3.14": {
+      "integrity": "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@bomb.sh/tab@0.0.11_citty@0.1.6": {
       "integrity": "sha512-RSqyreeicYBALcMaNxIUJTBknftXsyW45VRq5gKDNwKroh0Re5SDoWwXZaphb+OTEzVdpm/BA8Uq6y0P+AtVYw==",
@@ -543,7 +602,15 @@
       "dependencies": [
         "@nuxt/kit@4.3.0_magicast@0.5.1",
         "execa",
-        "vite"
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3"
+      ]
+    },
+    "@nuxt/devtools-kit@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_magicast@0.5.1_@types+node@24.2.0": {
+      "integrity": "sha512-sjiKFeDCOy1SyqezSgyV4rYNfQewC64k/GhOsuJgRF+wR2qr6KTVhO6u2B+csKs74KrMrnJprQBgud7ejvOXAQ==",
+      "dependencies": [
+        "@nuxt/kit@4.3.0_magicast@0.5.1",
+        "execa",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0"
       ]
     },
     "@nuxt/devtools-wizard@3.1.1": {
@@ -563,10 +630,10 @@
     "@nuxt/devtools@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_magicast@0.5.1": {
       "integrity": "sha512-UG8oKQqcSyzwBe1l0z24zypmwn6FLW/HQMHK/F/gscUU5LeMHzgBhLPD+cuLlDvwlGAbifexWNMsS/I7n95KlA==",
       "dependencies": [
-        "@nuxt/devtools-kit",
+        "@nuxt/devtools-kit@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_magicast@0.5.1",
         "@nuxt/devtools-wizard",
         "@nuxt/kit@4.3.0_magicast@0.5.1",
-        "@vue/devtools-core",
+        "@vue/devtools-core@8.0.5_vue@3.5.27_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1",
         "@vue/devtools-kit",
         "birpc",
         "consola",
@@ -591,9 +658,48 @@
         "sirv",
         "structured-clone-es",
         "tinyglobby",
-        "vite",
-        "vite-plugin-inspect",
-        "vite-plugin-vue-tracer",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3",
+        "vite-plugin-inspect@11.3.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1",
+        "vite-plugin-vue-tracer@1.2.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1",
+        "which@5.0.0",
+        "ws"
+      ],
+      "bin": true
+    },
+    "@nuxt/devtools@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_magicast@0.5.1_@types+node@24.2.0": {
+      "integrity": "sha512-UG8oKQqcSyzwBe1l0z24zypmwn6FLW/HQMHK/F/gscUU5LeMHzgBhLPD+cuLlDvwlGAbifexWNMsS/I7n95KlA==",
+      "dependencies": [
+        "@nuxt/devtools-kit@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_magicast@0.5.1_@types+node@24.2.0",
+        "@nuxt/devtools-wizard",
+        "@nuxt/kit@4.3.0_magicast@0.5.1",
+        "@vue/devtools-core@8.0.5_vue@3.5.27_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0",
+        "@vue/devtools-kit",
+        "birpc",
+        "consola",
+        "destr",
+        "error-stack-parser-es",
+        "execa",
+        "fast-npm-meta",
+        "get-port-please",
+        "hookable@5.5.3",
+        "image-meta",
+        "is-installed-globally",
+        "launch-editor",
+        "local-pkg",
+        "magicast",
+        "nypm",
+        "ohash",
+        "pathe@2.0.3",
+        "perfect-debounce",
+        "pkg-types@2.3.0",
+        "semver@7.7.3",
+        "simple-git",
+        "sirv",
+        "structured-clone-es",
+        "tinyglobby",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0",
+        "vite-plugin-inspect@11.3.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0",
+        "vite-plugin-vue-tracer@1.2.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_@types+node@24.2.0",
         "which@5.0.0",
         "ws"
       ],
@@ -708,6 +814,72 @@
         "vue-devtools-stub"
       ]
     },
+    "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_@types+node@24.2.0": {
+      "integrity": "sha512-NkI8q8211BTLfQr6m24PjBp9GGyKWJMxRGSqe5WGgpQD5BpSnlvM8l1HaaP4xn9/P4v1Hp/LxX+vYElY2fw/zw==",
+      "dependencies": [
+        "@nuxt/devalue",
+        "@nuxt/kit@4.3.0",
+        "@unhead/vue",
+        "@vue/shared",
+        "consola",
+        "defu",
+        "destr",
+        "devalue",
+        "errx",
+        "escape-string-regexp",
+        "exsolve",
+        "h3",
+        "impound",
+        "klona",
+        "mocked-exports",
+        "nitropack",
+        "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_@types+node@24.2.0",
+        "ohash",
+        "pathe@2.0.3",
+        "pkg-types@2.3.0",
+        "rou3",
+        "std-env",
+        "ufo",
+        "unctx",
+        "unstorage",
+        "vue",
+        "vue-bundle-renderer",
+        "vue-devtools-stub"
+      ]
+    },
+    "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_@types+node@24.2.0_@biomejs+biome@2.3.14": {
+      "integrity": "sha512-NkI8q8211BTLfQr6m24PjBp9GGyKWJMxRGSqe5WGgpQD5BpSnlvM8l1HaaP4xn9/P4v1Hp/LxX+vYElY2fw/zw==",
+      "dependencies": [
+        "@nuxt/devalue",
+        "@nuxt/kit@4.3.0",
+        "@unhead/vue",
+        "@vue/shared",
+        "consola",
+        "defu",
+        "destr",
+        "devalue",
+        "errx",
+        "escape-string-regexp",
+        "exsolve",
+        "h3",
+        "impound",
+        "klona",
+        "mocked-exports",
+        "nitropack",
+        "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_@types+node@24.2.0_@biomejs+biome@2.3.14",
+        "ohash",
+        "pathe@2.0.3",
+        "pkg-types@2.3.0",
+        "rou3",
+        "std-env",
+        "ufo",
+        "unctx",
+        "unstorage",
+        "vue",
+        "vue-bundle-renderer",
+        "vue-devtools-stub"
+      ]
+    },
     "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6": {
       "integrity": "sha512-NkI8q8211BTLfQr6m24PjBp9GGyKWJMxRGSqe5WGgpQD5BpSnlvM8l1HaaP4xn9/P4v1Hp/LxX+vYElY2fw/zw==",
       "dependencies": [
@@ -728,6 +900,72 @@
         "mocked-exports",
         "nitropack",
         "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6",
+        "ohash",
+        "pathe@2.0.3",
+        "pkg-types@2.3.0",
+        "rou3",
+        "std-env",
+        "ufo",
+        "unctx",
+        "unstorage",
+        "vue",
+        "vue-bundle-renderer",
+        "vue-devtools-stub"
+      ]
+    },
+    "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0": {
+      "integrity": "sha512-NkI8q8211BTLfQr6m24PjBp9GGyKWJMxRGSqe5WGgpQD5BpSnlvM8l1HaaP4xn9/P4v1Hp/LxX+vYElY2fw/zw==",
+      "dependencies": [
+        "@nuxt/devalue",
+        "@nuxt/kit@4.3.0",
+        "@unhead/vue",
+        "@vue/shared",
+        "consola",
+        "defu",
+        "destr",
+        "devalue",
+        "errx",
+        "escape-string-regexp",
+        "exsolve",
+        "h3",
+        "impound",
+        "klona",
+        "mocked-exports",
+        "nitropack",
+        "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0",
+        "ohash",
+        "pathe@2.0.3",
+        "pkg-types@2.3.0",
+        "rou3",
+        "std-env",
+        "ufo",
+        "unctx",
+        "unstorage",
+        "vue",
+        "vue-bundle-renderer",
+        "vue-devtools-stub"
+      ]
+    },
+    "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0_@biomejs+biome@2.3.14": {
+      "integrity": "sha512-NkI8q8211BTLfQr6m24PjBp9GGyKWJMxRGSqe5WGgpQD5BpSnlvM8l1HaaP4xn9/P4v1Hp/LxX+vYElY2fw/zw==",
+      "dependencies": [
+        "@nuxt/devalue",
+        "@nuxt/kit@4.3.0",
+        "@unhead/vue",
+        "@vue/shared",
+        "consola",
+        "defu",
+        "destr",
+        "devalue",
+        "errx",
+        "escape-string-regexp",
+        "exsolve",
+        "h3",
+        "impound",
+        "klona",
+        "mocked-exports",
+        "nitropack",
+        "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0_@biomejs+biome@2.3.14",
         "ohash",
         "pathe@2.0.3",
         "pkg-types@2.3.0",
@@ -774,8 +1012,8 @@
       "dependencies": [
         "@nuxt/kit@4.3.0",
         "@rollup/plugin-replace",
-        "@vitejs/plugin-vue",
-        "@vitejs/plugin-vue-jsx",
+        "@vitejs/plugin-vue@6.0.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1",
+        "@vitejs/plugin-vue-jsx@5.1.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_@babel+core@7.28.6_jiti@2.6.1",
         "autoprefixer",
         "consola",
         "cssnano",
@@ -798,9 +1036,81 @@
         "std-env",
         "ufo",
         "unenv",
-        "vite",
-        "vite-node",
-        "vite-plugin-checker",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3",
+        "vite-node@5.3.0_jiti@2.6.1",
+        "vite-plugin-checker@0.12.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1",
+        "vue",
+        "vue-bundle-renderer"
+      ]
+    },
+    "@nuxt/vite-builder@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0": {
+      "integrity": "sha512-qOVevlukWUztfJ9p/OtujRxwaXIsnoTo2ZW4pPY1zQcuR1DtBtBsiePLzftoDz1VGx9JF5GAx9YyrgTn/EmcWQ==",
+      "dependencies": [
+        "@nuxt/kit@4.3.0",
+        "@rollup/plugin-replace",
+        "@vitejs/plugin-vue@6.0.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_@types+node@24.2.0",
+        "@vitejs/plugin-vue-jsx@5.1.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_@babel+core@7.28.6_jiti@2.6.1_@types+node@24.2.0",
+        "autoprefixer",
+        "consola",
+        "cssnano",
+        "defu",
+        "esbuild",
+        "escape-string-regexp",
+        "exsolve",
+        "get-port-please",
+        "jiti",
+        "knitwork",
+        "magic-string",
+        "mlly",
+        "mocked-exports",
+        "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0",
+        "pathe@2.0.3",
+        "pkg-types@2.3.0",
+        "postcss",
+        "rollup-plugin-visualizer",
+        "seroval",
+        "std-env",
+        "ufo",
+        "unenv",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0",
+        "vite-node@5.3.0_jiti@2.6.1_@types+node@24.2.0",
+        "vite-plugin-checker@0.12.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0",
+        "vue",
+        "vue-bundle-renderer"
+      ]
+    },
+    "@nuxt/vite-builder@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0_@biomejs+biome@2.3.14": {
+      "integrity": "sha512-qOVevlukWUztfJ9p/OtujRxwaXIsnoTo2ZW4pPY1zQcuR1DtBtBsiePLzftoDz1VGx9JF5GAx9YyrgTn/EmcWQ==",
+      "dependencies": [
+        "@nuxt/kit@4.3.0",
+        "@rollup/plugin-replace",
+        "@vitejs/plugin-vue@6.0.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_@types+node@24.2.0",
+        "@vitejs/plugin-vue-jsx@5.1.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_@babel+core@7.28.6_jiti@2.6.1_@types+node@24.2.0",
+        "autoprefixer",
+        "consola",
+        "cssnano",
+        "defu",
+        "esbuild",
+        "escape-string-regexp",
+        "exsolve",
+        "get-port-please",
+        "jiti",
+        "knitwork",
+        "magic-string",
+        "mlly",
+        "mocked-exports",
+        "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0_@biomejs+biome@2.3.14",
+        "pathe@2.0.3",
+        "pkg-types@2.3.0",
+        "postcss",
+        "rollup-plugin-visualizer",
+        "seroval",
+        "std-env",
+        "ufo",
+        "unenv",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0",
+        "vite-node@5.3.0_jiti@2.6.1_@types+node@24.2.0",
+        "vite-plugin-checker@0.12.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0_@biomejs+biome@2.3.14",
         "vue",
         "vue-bundle-renderer"
       ]
@@ -1480,6 +1790,12 @@
     "@types/estree@1.0.8": {
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
     },
+    "@types/node@24.2.0": {
+      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
     "@types/parse-path@7.1.0": {
       "integrity": "sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==",
       "dependencies": [
@@ -1524,7 +1840,19 @@
         "@babel/plugin-transform-typescript",
         "@rolldown/pluginutils@1.0.0-rc.2",
         "@vue/babel-plugin-jsx",
-        "vite",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3",
+        "vue"
+      ]
+    },
+    "@vitejs/plugin-vue-jsx@5.1.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_@babel+core@7.28.6_jiti@2.6.1_@types+node@24.2.0": {
+      "integrity": "sha512-I6Zr8cYVr5WHMW5gNOP09DNqW9rgO8RX73Wa6Czgq/0ndpTfJM4vfDChfOT1+3KtdrNqilNBtNlFwVeB02ZzGw==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/plugin-syntax-typescript",
+        "@babel/plugin-transform-typescript",
+        "@rolldown/pluginutils@1.0.0-rc.2",
+        "@vue/babel-plugin-jsx",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0",
         "vue"
       ]
     },
@@ -1532,7 +1860,15 @@
       "integrity": "sha512-TlGPkLFLVOY3T7fZrwdvKpjprR3s4fxRln0ORDo1VQ7HHyxJwTlrjKU3kpVWTlaAjIEuCTokmjkZnr8Tpc925w==",
       "dependencies": [
         "@rolldown/pluginutils@1.0.0-beta.53",
-        "vite",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3",
+        "vue"
+      ]
+    },
+    "@vitejs/plugin-vue@6.0.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_@types+node@24.2.0": {
+      "integrity": "sha512-TlGPkLFLVOY3T7fZrwdvKpjprR3s4fxRln0ORDo1VQ7HHyxJwTlrjKU3kpVWTlaAjIEuCTokmjkZnr8Tpc925w==",
+      "dependencies": [
+        "@rolldown/pluginutils@1.0.0-beta.53",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0",
         "vue"
       ]
     },
@@ -1640,7 +1976,19 @@
         "mitt",
         "nanoid@5.1.6",
         "pathe@2.0.3",
-        "vite-hot-client",
+        "vite-hot-client@2.1.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1",
+        "vue"
+      ]
+    },
+    "@vue/devtools-core@8.0.5_vue@3.5.27_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0": {
+      "integrity": "sha512-dpCw8nl0GDBuiL9SaY0mtDxoGIEmU38w+TQiYEPOLhW03VDC0lfNMYXS/qhl4I0YlysGp04NLY4UNn6xgD0VIQ==",
+      "dependencies": [
+        "@vue/devtools-kit",
+        "@vue/devtools-shared",
+        "mitt",
+        "nanoid@5.1.6",
+        "pathe@2.0.3",
+        "vite-hot-client@2.1.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0",
         "vue"
       ]
     },
@@ -2475,6 +2823,7 @@
         "package-json-from-dist",
         "path-scurry@1.11.1"
       ],
+      "deprecated": true,
       "bin": true
     },
     "glob@13.0.0": {
@@ -3089,12 +3438,12 @@
       "dependencies": [
         "@dxup/nuxt",
         "@nuxt/cli",
-        "@nuxt/devtools",
+        "@nuxt/devtools@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_magicast@0.5.1",
         "@nuxt/kit@4.3.0",
         "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1",
         "@nuxt/schema",
         "@nuxt/telemetry",
-        "@nuxt/vite-builder",
+        "@nuxt/vite-builder@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6",
         "@unhead/vue",
         "@vue/shared",
         "c12",
@@ -3147,17 +3496,18 @@
       ],
       "bin": true
     },
-    "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6": {
+    "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_@types+node@24.2.0": {
       "integrity": "sha512-99Iw3E3L5/2QtJyV4errZ0axkX/S9IAFK0AHm0pmRHkCu37OFn8mz2P4/CYTt6B/TG3mcKbXAVaeuF2FsAc1cA==",
       "dependencies": [
         "@dxup/nuxt",
         "@nuxt/cli",
-        "@nuxt/devtools",
+        "@nuxt/devtools@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_magicast@0.5.1_@types+node@24.2.0",
         "@nuxt/kit@4.3.0",
-        "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6",
+        "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_@types+node@24.2.0",
         "@nuxt/schema",
         "@nuxt/telemetry",
-        "@nuxt/vite-builder",
+        "@nuxt/vite-builder@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0",
+        "@types/node",
         "@unhead/vue",
         "@vue/shared",
         "c12",
@@ -3207,6 +3557,273 @@
         "untyped",
         "vue",
         "vue-router"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ],
+      "bin": true
+    },
+    "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_@types+node@24.2.0_@biomejs+biome@2.3.14": {
+      "integrity": "sha512-99Iw3E3L5/2QtJyV4errZ0axkX/S9IAFK0AHm0pmRHkCu37OFn8mz2P4/CYTt6B/TG3mcKbXAVaeuF2FsAc1cA==",
+      "dependencies": [
+        "@dxup/nuxt",
+        "@nuxt/cli",
+        "@nuxt/devtools@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_magicast@0.5.1_@types+node@24.2.0",
+        "@nuxt/kit@4.3.0",
+        "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_@types+node@24.2.0_@biomejs+biome@2.3.14",
+        "@nuxt/schema",
+        "@nuxt/telemetry",
+        "@nuxt/vite-builder@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0_@biomejs+biome@2.3.14",
+        "@types/node",
+        "@unhead/vue",
+        "@vue/shared",
+        "c12",
+        "chokidar@5.0.0",
+        "compatx",
+        "consola",
+        "cookie-es@2.0.0",
+        "defu",
+        "destr",
+        "devalue",
+        "errx",
+        "escape-string-regexp",
+        "exsolve",
+        "h3",
+        "hookable@5.5.3",
+        "ignore",
+        "impound",
+        "jiti",
+        "klona",
+        "knitwork",
+        "magic-string",
+        "mlly",
+        "nanotar",
+        "nypm",
+        "ofetch",
+        "ohash",
+        "on-change",
+        "oxc-minify",
+        "oxc-parser",
+        "oxc-transform",
+        "oxc-walker",
+        "pathe@2.0.3",
+        "perfect-debounce",
+        "pkg-types@2.3.0",
+        "rou3",
+        "scule",
+        "semver@7.7.3",
+        "std-env",
+        "tinyglobby",
+        "ufo",
+        "ultrahtml",
+        "uncrypto",
+        "unctx",
+        "unimport",
+        "unplugin",
+        "unplugin-vue-router",
+        "untyped",
+        "vue",
+        "vue-router"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ],
+      "bin": true
+    },
+    "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6": {
+      "integrity": "sha512-99Iw3E3L5/2QtJyV4errZ0axkX/S9IAFK0AHm0pmRHkCu37OFn8mz2P4/CYTt6B/TG3mcKbXAVaeuF2FsAc1cA==",
+      "dependencies": [
+        "@dxup/nuxt",
+        "@nuxt/cli",
+        "@nuxt/devtools@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_magicast@0.5.1",
+        "@nuxt/kit@4.3.0",
+        "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6",
+        "@nuxt/schema",
+        "@nuxt/telemetry",
+        "@nuxt/vite-builder@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6",
+        "@unhead/vue",
+        "@vue/shared",
+        "c12",
+        "chokidar@5.0.0",
+        "compatx",
+        "consola",
+        "cookie-es@2.0.0",
+        "defu",
+        "destr",
+        "devalue",
+        "errx",
+        "escape-string-regexp",
+        "exsolve",
+        "h3",
+        "hookable@5.5.3",
+        "ignore",
+        "impound",
+        "jiti",
+        "klona",
+        "knitwork",
+        "magic-string",
+        "mlly",
+        "nanotar",
+        "nypm",
+        "ofetch",
+        "ohash",
+        "on-change",
+        "oxc-minify",
+        "oxc-parser",
+        "oxc-transform",
+        "oxc-walker",
+        "pathe@2.0.3",
+        "perfect-debounce",
+        "pkg-types@2.3.0",
+        "rou3",
+        "scule",
+        "semver@7.7.3",
+        "std-env",
+        "tinyglobby",
+        "ufo",
+        "ultrahtml",
+        "uncrypto",
+        "unctx",
+        "unimport",
+        "unplugin",
+        "unplugin-vue-router",
+        "untyped",
+        "vue",
+        "vue-router"
+      ],
+      "bin": true
+    },
+    "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0": {
+      "integrity": "sha512-99Iw3E3L5/2QtJyV4errZ0axkX/S9IAFK0AHm0pmRHkCu37OFn8mz2P4/CYTt6B/TG3mcKbXAVaeuF2FsAc1cA==",
+      "dependencies": [
+        "@dxup/nuxt",
+        "@nuxt/cli",
+        "@nuxt/devtools@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_magicast@0.5.1_@types+node@24.2.0",
+        "@nuxt/kit@4.3.0",
+        "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0",
+        "@nuxt/schema",
+        "@nuxt/telemetry",
+        "@nuxt/vite-builder@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6",
+        "@types/node",
+        "@unhead/vue",
+        "@vue/shared",
+        "c12",
+        "chokidar@5.0.0",
+        "compatx",
+        "consola",
+        "cookie-es@2.0.0",
+        "defu",
+        "destr",
+        "devalue",
+        "errx",
+        "escape-string-regexp",
+        "exsolve",
+        "h3",
+        "hookable@5.5.3",
+        "ignore",
+        "impound",
+        "jiti",
+        "klona",
+        "knitwork",
+        "magic-string",
+        "mlly",
+        "nanotar",
+        "nypm",
+        "ofetch",
+        "ohash",
+        "on-change",
+        "oxc-minify",
+        "oxc-parser",
+        "oxc-transform",
+        "oxc-walker",
+        "pathe@2.0.3",
+        "perfect-debounce",
+        "pkg-types@2.3.0",
+        "rou3",
+        "scule",
+        "semver@7.7.3",
+        "std-env",
+        "tinyglobby",
+        "ufo",
+        "ultrahtml",
+        "uncrypto",
+        "unctx",
+        "unimport",
+        "unplugin",
+        "unplugin-vue-router",
+        "untyped",
+        "vue",
+        "vue-router"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ],
+      "bin": true
+    },
+    "nuxt@4.3.0_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0_@biomejs+biome@2.3.14": {
+      "integrity": "sha512-99Iw3E3L5/2QtJyV4errZ0axkX/S9IAFK0AHm0pmRHkCu37OFn8mz2P4/CYTt6B/TG3mcKbXAVaeuF2FsAc1cA==",
+      "dependencies": [
+        "@dxup/nuxt",
+        "@nuxt/cli",
+        "@nuxt/devtools@3.1.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_magicast@0.5.1_@types+node@24.2.0",
+        "@nuxt/kit@4.3.0",
+        "@nuxt/nitro-server@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6_@types+node@24.2.0_@biomejs+biome@2.3.14",
+        "@nuxt/schema",
+        "@nuxt/telemetry",
+        "@nuxt/vite-builder@4.3.0_nuxt@4.3.0__vue@3.5.27__oxc-parser@0.110.0__vue-router@4.6.4___vue@3.5.27__jiti@2.6.1_vue@3.5.27_oxc-parser@0.110.0_vue-router@4.6.4__vue@3.5.27_jiti@2.6.1_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_postcss@8.5.6",
+        "@types/node",
+        "@unhead/vue",
+        "@vue/shared",
+        "c12",
+        "chokidar@5.0.0",
+        "compatx",
+        "consola",
+        "cookie-es@2.0.0",
+        "defu",
+        "destr",
+        "devalue",
+        "errx",
+        "escape-string-regexp",
+        "exsolve",
+        "h3",
+        "hookable@5.5.3",
+        "ignore",
+        "impound",
+        "jiti",
+        "klona",
+        "knitwork",
+        "magic-string",
+        "mlly",
+        "nanotar",
+        "nypm",
+        "ofetch",
+        "ohash",
+        "on-change",
+        "oxc-minify",
+        "oxc-parser",
+        "oxc-transform",
+        "oxc-walker",
+        "pathe@2.0.3",
+        "perfect-debounce",
+        "pkg-types@2.3.0",
+        "rou3",
+        "scule",
+        "semver@7.7.3",
+        "std-env",
+        "tinyglobby",
+        "ufo",
+        "ultrahtml",
+        "uncrypto",
+        "unctx",
+        "unimport",
+        "unplugin",
+        "unplugin-vue-router",
+        "untyped",
+        "vue",
+        "vue-router"
+      ],
+      "optionalPeers": [
+        "@types/node"
       ],
       "bin": true
     },
@@ -4155,6 +4772,9 @@
         "unplugin"
       ]
     },
+    "undici-types@7.10.0": {
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
+    },
     "unenv@2.0.0-rc.24": {
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dependencies": [
@@ -4311,14 +4931,28 @@
       "integrity": "sha512-pKXZlgoXGoE8sEKiKJSng4hI1sQ4wi5YT24FCrwrLt6opmkjlqPPVmiPWWJn8M8byMxRGzp1CrFuqQs4M/Z39A==",
       "dependencies": [
         "birpc",
-        "vite",
-        "vite-hot-client"
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3",
+        "vite-hot-client@2.1.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1"
+      ]
+    },
+    "vite-dev-rpc@1.1.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0": {
+      "integrity": "sha512-pKXZlgoXGoE8sEKiKJSng4hI1sQ4wi5YT24FCrwrLt6opmkjlqPPVmiPWWJn8M8byMxRGzp1CrFuqQs4M/Z39A==",
+      "dependencies": [
+        "birpc",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0",
+        "vite-hot-client@2.1.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0"
       ]
     },
     "vite-hot-client@2.1.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1": {
       "integrity": "sha512-7SpgZmU7R+dDnSmvXE1mfDtnHLHQSisdySVR7lO8ceAXvM0otZeuQQ6C8LrS5d/aYyP/QZ0hI0L+dIPrm4YlFQ==",
       "dependencies": [
-        "vite"
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3"
+      ]
+    },
+    "vite-hot-client@2.1.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0": {
+      "integrity": "sha512-7SpgZmU7R+dDnSmvXE1mfDtnHLHQSisdySVR7lO8ceAXvM0otZeuQQ6C8LrS5d/aYyP/QZ0hI0L+dIPrm4YlFQ==",
+      "dependencies": [
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0"
       ]
     },
     "vite-node@5.3.0_jiti@2.6.1": {
@@ -4328,7 +4962,18 @@
         "es-module-lexer",
         "obug",
         "pathe@2.0.3",
-        "vite"
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3"
+      ],
+      "bin": true
+    },
+    "vite-node@5.3.0_jiti@2.6.1_@types+node@24.2.0": {
+      "integrity": "sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==",
+      "dependencies": [
+        "cac",
+        "es-module-lexer",
+        "obug",
+        "pathe@2.0.3",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0"
       ],
       "bin": true
     },
@@ -4342,8 +4987,40 @@
         "picomatch@4.0.3",
         "tiny-invariant",
         "tinyglobby",
-        "vite",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3",
         "vscode-uri"
+      ]
+    },
+    "vite-plugin-checker@0.12.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0": {
+      "integrity": "sha512-CmdZdDOGss7kdQwv73UyVgLPv0FVYe5czAgnmRX2oKljgEvSrODGuClaV3PDR2+3ou7N/OKGauDDBjy2MB07Rg==",
+      "dependencies": [
+        "@babel/code-frame",
+        "chokidar@4.0.3",
+        "npm-run-path@6.0.0",
+        "picocolors",
+        "picomatch@4.0.3",
+        "tiny-invariant",
+        "tinyglobby",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0",
+        "vscode-uri"
+      ]
+    },
+    "vite-plugin-checker@0.12.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0_@biomejs+biome@2.3.14": {
+      "integrity": "sha512-CmdZdDOGss7kdQwv73UyVgLPv0FVYe5czAgnmRX2oKljgEvSrODGuClaV3PDR2+3ou7N/OKGauDDBjy2MB07Rg==",
+      "dependencies": [
+        "@babel/code-frame",
+        "@biomejs/biome",
+        "chokidar@4.0.3",
+        "npm-run-path@6.0.0",
+        "picocolors",
+        "picomatch@4.0.3",
+        "tiny-invariant",
+        "tinyglobby",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0",
+        "vscode-uri"
+      ],
+      "optionalPeers": [
+        "@biomejs/biome"
       ]
     },
     "vite-plugin-inspect@11.3.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1": {
@@ -4357,8 +5034,23 @@
         "perfect-debounce",
         "sirv",
         "unplugin-utils@0.3.1",
-        "vite",
-        "vite-dev-rpc"
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3",
+        "vite-dev-rpc@1.1.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1"
+      ]
+    },
+    "vite-plugin-inspect@11.3.3_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0": {
+      "integrity": "sha512-u2eV5La99oHoYPHE6UvbwgEqKKOQGz86wMg40CCosP6q8BkB6e5xPneZfYagK4ojPJSj5anHCrnvC20DpwVdRA==",
+      "dependencies": [
+        "ansis",
+        "debug",
+        "error-stack-parser-es",
+        "ohash",
+        "open@10.2.0",
+        "perfect-debounce",
+        "sirv",
+        "unplugin-utils@0.3.1",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0",
+        "vite-dev-rpc@1.1.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_jiti@2.6.1_@types+node@24.2.0"
       ]
     },
     "vite-plugin-vue-tracer@1.2.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1": {
@@ -4369,7 +5061,19 @@
         "magic-string",
         "pathe@2.0.3",
         "source-map-js",
-        "vite",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3",
+        "vue"
+      ]
+    },
+    "vite-plugin-vue-tracer@1.2.0_vite@7.3.1__jiti@2.6.1__picomatch@4.0.3_vue@3.5.27_jiti@2.6.1_@types+node@24.2.0": {
+      "integrity": "sha512-a9Z/TLpxwmoE9kIcv28wqQmiszM7ec4zgndXWEsVD/2lEZLRGzcg7ONXmplzGF/UP5W59QNtS809OdywwpUWQQ==",
+      "dependencies": [
+        "estree-walker@3.0.3",
+        "exsolve",
+        "magic-string",
+        "pathe@2.0.3",
+        "source-map-js",
+        "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0",
         "vue"
       ]
     },
@@ -4388,6 +5092,27 @@
         "fsevents"
       ],
       "optionalPeers": [
+        "jiti"
+      ],
+      "bin": true
+    },
+    "vite@7.3.1_jiti@2.6.1_picomatch@4.0.3_@types+node@24.2.0": {
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dependencies": [
+        "@types/node",
+        "esbuild",
+        "fdir",
+        "jiti",
+        "picomatch@4.0.3",
+        "postcss",
+        "rollup",
+        "tinyglobby"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "optionalPeers": [
+        "@types/node",
         "jiti"
       ],
       "bin": true
@@ -4530,6 +5255,7 @@
   "workspace": {
     "packageJson": {
       "dependencies": [
+        "npm:@biomejs/biome@^2.3.14",
         "npm:nuxt@^4.3.0",
         "npm:vue-router@^4.6.4",
         "npm:vue@^3.5.27"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,32 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import process from "node:process";
 export default defineNuxtConfig({
-  compatibilityDate: '2025-07-15',
-  devtools: { enabled: true }
+	compatibilityDate: "2025-07-15",
+	devtools: { enabled: true },
+
+	modules: [],
+
+  css: ['~/assets/css/main.css'],
+
+	// runtimeConfig: {
+	// 	public: {
+	// 		supabaseUrl: process.env.SUPABASE_URL,
+	// 		supabaseAnonKey: process.env.SUPABASE_ANON_KEY,
+	// 	},
+	// },
+
+	app: {
+		head: {
+			title: "Cat Gallery",
+			meta: [
+				{ charset: "utf-8" },
+				{ name: "viewport", content: "width=device-width, initial-scale=1" },
+				{
+					name: "description",
+					content: "ねこの写真を保存・閲覧できるギャラリーアプリ",
+				},
+			],
+		},
+	},
+
 })

--- a/package.json
+++ b/package.json
@@ -1,17 +1,20 @@
 {
-  "name": "catGallery",
-  "type": "module",
-  "private": true,
-  "scripts": {
-    "build": "nuxt build",
-    "dev": "nuxt dev",
-    "generate": "nuxt generate",
-    "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
-  },
-  "dependencies": {
-    "nuxt": "^4.3.0",
-    "vue": "^3.5.27",
-    "vue-router": "^4.6.4"
-  }
+	"name": "catGallery",
+	"type": "module",
+	"private": true,
+	"scripts": {
+		"build": "nuxt build",
+		"dev": "nuxt dev",
+		"generate": "nuxt generate",
+		"preview": "nuxt preview",
+		"postinstall": "nuxt prepare"
+	},
+	"dependencies": {
+		"nuxt": "^4.3.0",
+		"vue": "^3.5.27",
+		"vue-router": "^4.6.4"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.3.14"
+	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,18 @@
 {
-  // https://nuxt.com/docs/guide/concepts/typescript
-  "files": [],
-  "references": [
-    {
-      "path": "./.nuxt/tsconfig.app.json"
-    },
-    {
-      "path": "./.nuxt/tsconfig.server.json"
-    },
-    {
-      "path": "./.nuxt/tsconfig.shared.json"
-    },
-    {
-      "path": "./.nuxt/tsconfig.node.json"
-    }
-  ]
+	// https://nuxt.com/docs/guide/concepts/typescript
+	"files": [],
+	"references": [
+		{
+			"path": "./.nuxt/tsconfig.app.json"
+		},
+		{
+			"path": "./.nuxt/tsconfig.server.json"
+		},
+		{
+			"path": "./.nuxt/tsconfig.shared.json"
+		},
+		{
+			"path": "./.nuxt/tsconfig.node.json"
+		}
+	]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+	"buildCommand": "deno task build",
+	"devCommand": "deno task dev",
+	"installCommand": "deno install",
+	"framework": "nuxtjs",
+	"outputDirectory": ".output/public"
+}


### PR DESCRIPTION
close #3 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds/updates configuration and documentation; no production logic changes beyond basic Nuxt head/CSS wiring and build tooling, so risk is low.
> 
> **Overview**
> Adds project scaffolding/config for a Nuxt 4 app running under Deno, including `deno.json` task aliases, Biome lint/format setup (`biome.json` + `@biomejs/biome` devDependency), and Vercel deployment commands via `vercel.json`.
> 
> Introduces a `.env.example` for Supabase credentials and significantly expands `README.md` with Japanese setup/deploy/security guidance. Updates `nuxt.config.ts` to include global CSS (`app/assets/css/main.css`) and basic document head metadata (title/description), with commented-out `runtimeConfig` placeholders for Supabase env wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1e1c8bd9093fddb932282e9f9b1d87bf050a878. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->