### PR TITLE
モーダル表示中のスクロールを停止 #20

### DIFF
--- a/app/components/PhotoGalley.vue
+++ b/app/components/PhotoGalley.vue
@@ -128,9 +128,25 @@ const formatFileSize = (bytes: number): string => {
 	return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + " " + sizes[i]
 }
 
+/**
+ * モーダル表示時にbodyのスクロールを止める
+ */
+watch(selectedPhoto, (newValue) => {
+	if (newValue) {
+		document.body.style.overflow = 'hidden'
+	} else {
+		document.body.style.overflow = ''
+	}
+})
+
 // コンポーネントマウント時に写真を読み込む
 onMounted(() => {
 	loadPhotos()
+})
+
+// コンポーネントアンマウント時にスクロールを復元
+onUnmounted(() => {
+	document.body.style.overflow = ''
 })
 
 // 外部から再読み込みできるようにする


### PR DESCRIPTION
close #20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change that only toggles `document.body.style.overflow` based on modal visibility; potential edge cases if other components also manage body scroll.
> 
> **Overview**
> Prevents background page scrolling while the photo modal is open by watching `selectedPhoto` and setting `document.body.style.overflow = 'hidden'` when a photo is selected.
> 
> Also restores the body scroll state when the modal closes and on component unmount to avoid leaving the page in a non-scrollable state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b11f680bdd44c79d794934f0363d2e0222cb1d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->